### PR TITLE
Fix build for stack ghc 8.2.2

### DIFF
--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -49,12 +49,9 @@ extra-deps:
 - filepath-1.4.1.2
 - libyaml-0.1.1.0
 - transformers-0.5.6.2
-- containers-0.5.10.2
 - process-1.6.1.0
 - binary-0.8.5.1
 - unix-2.7.2.2
-# - Win32-2.6.2.
-- time-1.8.0.2
 
 flags:
   haskell-ide-engine:


### PR DESCRIPTION
I suppose this is related to boot libraries that ship with GHC that cant be recompiled?