### PR TITLE
Add proper support for the 'none' cradle

### DIFF
--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -99,7 +99,7 @@ run scheduler = flip E.catches handlers $ do
         case mreq of
           Nothing -> return()
           Just req -> do
-            let preq = GReq 0 (context req) Nothing (Just $ J.IdInt rid) (liftIO . callback)
+            let preq = GReq 0 (context req) Nothing (Just $ J.IdInt rid) (liftIO . callback) (toDynJSON (Nothing :: Maybe ()))
                   $ runPluginCommand (plugin req) (command req) (arg req)
                 rid = reqId req
                 callback = sendResponse rid . dynToJSON

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -22,9 +22,10 @@ pattern GReq :: TrackingNumber
              -> Maybe (Uri, Int)
              -> Maybe J.LspId
              -> RequestCallback m a1
+             -> a1
              -> IdeGhcM (IdeResult a1)
              -> PluginRequest m
-pattern GReq a b c d e f = Right (GhcRequest   a b c d e f)
+pattern GReq a b c d e f  g= Right (GhcRequest   a b c d e f g)
 
 pattern IReq :: TrackingNumber -> J.LspId -> RequestCallback m a -> IdeDeferM (IdeResult a) -> Either (IdeRequest m) b
 pattern IReq a b c d   = Left  (IdeRequest a b c d)
@@ -37,6 +38,7 @@ data GhcRequest m = forall a. GhcRequest
   , pinDocVer    :: Maybe (J.Uri, Int)
   , pinLspReqId  :: Maybe J.LspId
   , pinCallback  :: RequestCallback m a
+  , pinDefault   :: a
   , pinReq       :: IdeGhcM (IdeResult a)
   }
 

--- a/test/dispatcher/Main.hs
+++ b/test/dispatcher/Main.hs
@@ -101,7 +101,7 @@ dispatchGhcRequest tn uri ctx n scheduler lc plugin com arg = do
     logger :: RequestCallback IO DynamicJSON
     logger x = logToChan lc (ctx, Right x)
 
-  let req = GReq tn uri Nothing (Just (IdInt n)) logger $
+  let req = GReq tn uri Nothing (Just (IdInt n)) logger (toDynJSON (Nothing :: Maybe ())) $
         runPluginCommand plugin com (toJSON arg)
   sendRequest scheduler Nothing req
 

--- a/test/plugin-dispatcher/Main.hs
+++ b/test/plugin-dispatcher/Main.hs
@@ -34,11 +34,11 @@ newPluginSpec = do
       let defCallback = atomically . writeTChan outChan
           delayedCallback = \r -> threadDelay 10000 >> defCallback r
 
-      let req0 = GReq 0 Nothing Nothing                          (Just $ IdInt 0) (\_ -> return () :: IO ())         $ return $ IdeResultOk $ T.pack "text0"
-          req1 = GReq 1 Nothing Nothing                          (Just $ IdInt 1) defCallback $ return $ IdeResultOk $ T.pack "text1"
-          req2 = GReq 2 Nothing Nothing                          (Just $ IdInt 2) delayedCallback      $ return      $ IdeResultOk $ T.pack "text2"
-          req3 = GReq 3 Nothing (Just (filePathToUri "test", 2)) Nothing          defCallback $ return $ IdeResultOk $ T.pack "text3"
-          req4 = GReq 4 Nothing Nothing                          (Just $ IdInt 3) defCallback $ return $ IdeResultOk $ T.pack "text4"
+      let req0 = GReq 0 Nothing Nothing                          (Just $ IdInt 0) (\_ -> return () :: IO ()) "none" $ return $ IdeResultOk $ T.pack "text0"
+          req1 = GReq 1 Nothing Nothing                          (Just $ IdInt 1) defCallback "none" $ return $ IdeResultOk $ T.pack "text1"
+          req2 = GReq 2 Nothing Nothing                          (Just $ IdInt 2) delayedCallback  "none"  $ return      $ IdeResultOk $ T.pack "text2"
+          req3 = GReq 3 Nothing (Just (filePathToUri "test", 2)) Nothing          defCallback "none" $ return $ IdeResultOk $ T.pack "text3"
+          req4 = GReq 4 Nothing Nothing                          (Just $ IdInt 3) defCallback "none" $ return $ IdeResultOk $ T.pack "text4"
 
       let makeReq = sendRequest scheduler Nothing
 

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -48,11 +48,11 @@ dispatchRequestPGoto =
 
 -- ---------------------------------------------------------------------
 
-runWithContext :: Uri -> IdeGhcM a -> IdeGhcM a
+runWithContext :: Monoid a => Uri -> IdeGhcM (IdeResult a) -> IdeGhcM (IdeResult a)
 runWithContext uri act = case uriToFilePath uri of
   Just fp -> do
     df <- getSessionDynFlags
-    res <- runActionWithContext df (Just fp) act
+    res <- runActionWithContext df (Just fp) (IdeResultOk mempty) act
     case res of
       IdeResultOk a -> return a
       IdeResultFail err -> error $ "Could not run in context: " ++ show err


### PR DESCRIPTION
The main change here is making `runActionWithContext` take an additional
default argument which can be returned in the case that we discover that
we shouldn't try to understand or process a specific file we are asked
to understand.

