### PR TITLE
Use the LSP provided root directory to find the cradle

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -111,22 +111,13 @@ run opts = do
 
   Core.setupLogger mLogFileName ["hie", "hie-bios"] logLevel
 
-  d <- getCurrentDirectory
-  -- Get the cabal directory from the cradle
-  cradle <- findLocalCradle (d </> "File.hs")
-
-  projGhcVersion <- getProjectGhcVersion cradle
-  when (projGhcVersion /= hieGhcVersion) $
-    warningm $ "Mismatching GHC versions: Project is " ++ projGhcVersion
-            ++ ", HIE is " ++ hieGhcVersion
-
   origDir <- getCurrentDirectory
 
   maybe (pure ()) setCurrentDirectory $ projectRoot opts
 
   progName <- getProgName
   logm $  "Run entered for HIE(" ++ progName ++ ") " ++ version
-  logm $ "Current directory:" ++ d
+  logm $ "Current directory:" ++ origDir
   args <- getArgs
   logm $ "args:" ++ show args
 


### PR DESCRIPTION
When checking for GHC version.  This also removes the redundant check in
MainHie (I'm not sure why were checking twice). This will remove the
check for the JSON transport, but as far as I am aware this is
unmantained anyway.