### PR TITLE
Demote no access to the persisted file to debug messages

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -81,12 +81,10 @@ applyOneCmd = CmdSync $ \(AOP uri pos title) -> do
 applyOneCmd' :: Uri -> OneHint -> IdeGhcM (IdeResult WorkspaceEdit)
 applyOneCmd' uri oneHint = pluginGetFile "applyOne: " uri $ \fp -> do
   revMapp <- reverseFileMap
-  let resultFail = return $ IdeResultFail
-        (IdeError PluginError
-                  (T.pack "applyOne: no access to the persisted file.")
-                  Null
-        )
-  withMappedFile fp resultFail $ \file' -> do
+  let defaultResult = do
+        debugm "applyOne: no access to the persisted file."
+        return $ IdeResultOk mempty
+  withMappedFile fp defaultResult $ \file' -> do
     res <- liftToGhc $ applyHint file' (Just oneHint) revMapp
     logm $ "applyOneCmd:file=" ++ show fp
     logm $ "applyOneCmd:res=" ++ show res
@@ -104,13 +102,11 @@ applyAllCmd = CmdSync $ \uri -> do
 
 applyAllCmd' :: Uri -> IdeGhcM (IdeResult WorkspaceEdit)
 applyAllCmd' uri = pluginGetFile "applyAll: " uri $ \fp -> do
-  let resultFail = return $ IdeResultFail
-        (IdeError PluginError
-                  (T.pack "applyAll: no access to the persisted file.")
-                  Null
-        )
+  let defaultResult = do
+        debugm "applyAll: no access to the persisted file."
+        return $ IdeResultOk mempty
   revMapp <- reverseFileMap
-  withMappedFile fp resultFail $ \file' -> do
+  withMappedFile fp defaultResult $ \file' -> do
     res <- liftToGhc $ applyHint file' Nothing revMapp
     logm $ "applyAllCmd:res=" ++ show res
     case res of
@@ -127,12 +123,12 @@ lintCmd = CmdSync $ \uri -> do
 -- AZ:TODO: Why is this in IdeGhcM?
 lintCmd' :: Uri -> IdeGhcM (IdeResult PublishDiagnosticsParams)
 lintCmd' uri = pluginGetFile "lintCmd: " uri $ \fp -> do
-  let resultFail = return $ IdeResultFail
-        (IdeError PluginError
-                  (T.pack "lintCmd: no access to the persisted file.")
-                  Null
-        )
-  withMappedFile fp resultFail $ \file' -> do
+  let
+    defaultResult = do
+      debugm "lintCmd: no access to the persisted file."
+      return
+        $ IdeResultOk (PublishDiagnosticsParams (filePathToUri fp) $ List [])
+  withMappedFile fp defaultResult $ \file' -> do
     eitherErrorResult <- liftIO
       (try $ runExceptT $ runLintCmd file' [] :: IO
           (Either IOException (Either [Diagnostic] [Idea]))

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -216,12 +216,11 @@ makeRefactorResult changedFiles = do
 
       origTextResult <- case mvf of
         Nothing -> do
-          let resultFail = return $ IdeResultFail
-                          (IdeError PluginError
-                            (T.pack "makeRefactorResult: no access to the persisted file.")
-                            Null
-                          )
-          withMappedFile fp resultFail (fmap IdeResultOk . liftIO . T.readFile)
+          let defaultResult = do
+                debugm "makeRefactorResult: no access to the persisted file."
+                return $ IdeResultOk mempty
+
+          withMappedFile fp defaultResult (fmap IdeResultOk . liftIO . T.readFile)
         Just vf -> return $ IdeResultOk $ Rope.toText $ _text vf
 
       case origTextResult of

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -17,6 +17,7 @@ import qualified GHC.Generics                  as Generics
 import qualified HsImport
 import           Haskell.Ide.Engine.Config
 import           Haskell.Ide.Engine.MonadTypes
+import           Haskell.Ide.Engine.MonadFunctions (debugm)
 import qualified Haskell.Ide.Engine.Support.HieExtras as Hie
 import qualified Language.Haskell.LSP.Types      as J
 import qualified Language.Haskell.LSP.Types.Lens as J
@@ -128,12 +129,10 @@ importModule uri impStyle modName =
   pluginGetFile "hsimport cmd: " uri $ \origInput -> do
     shouldFormat <- formatOnImportOn <$> getConfig
     fileMap      <- reverseFileMap
-    let resultFail = return $ IdeResultFail
-          (IdeError PluginError
-                    (T.pack $ "hsImport: no access to the persisted file.")
-                    Null
-          )
-    withMappedFile origInput resultFail $ \input -> do
+    let defaultResult = do
+          debugm "hsimport: no access to the persisted file."
+          return $ IdeResultOk mempty
+    withMappedFile origInput defaultResult $ \input -> do
       tmpDir            <- liftIO getTemporaryDirectory
       (output, outputH) <- liftIO $ openTempFile tmpDir "hsimportOutput"
       liftIO $ hClose outputH


### PR DESCRIPTION
It is not really an error as it may happen if the file you want to lint had been closed before the lint can be applied.