### PR TITLE
Detect files in main-is of components for cabal-helper cradle

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
@@ -467,10 +467,17 @@ partOfComponent fp' comp
   | otherwise
   = False
   where
+    -- Check if the FilePath is in an executable or setup's main-is field
+    inMainIs :: FilePath -> Bool
+    inMainIs fp
+      | ChExeEntrypoint mainIs _ <- ciEntrypoints comp = mainIs == fp
+      | ChSetupEntrypoint mainIs <- ciEntrypoints comp = mainIs == fp
+      | otherwise = False
+
     inTargets :: [FilePath] -> FilePath -> [String] -> Bool
     inTargets sourceDirs fp targets
       | Just relative <- relativeTo fp sourceDirs
-      = any (`elem` targets) [getModuleName relative, fp]
+      = any (`elem` targets) [getModuleName relative, fp] || inMainIs relative
       | otherwise
       = False
 

--- a/test/functional/HieBiosSpec.hs
+++ b/test/functional/HieBiosSpec.hs
@@ -10,7 +10,11 @@ import Test.Hspec
 import TestUtils
 
 spec :: Spec
-spec = describe "hie-bios" $
+spec = describe "hie-bios" $ do
+  it "loads modules inside main-is" $ runSession hieCommand fullCaps "test/testdata/hieBiosMainIs" $ do
+    _ <- openDoc "Main.hs" "haskell"
+    _ <- count 2 waitForDiagnostics
+    return ()
   it "reports errors in hie.yaml" $ runSession hieCommand fullCaps "test/testdata/hieBiosError" $ do
     _ <- openDoc "Foo.hs" "haskell"
     _ <- skipManyTill loggingNotification (satisfy isMessage)

--- a/test/testdata/hieBiosMainIs/Main.hs
+++ b/test/testdata/hieBiosMainIs/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/test/testdata/hieBiosMainIs/Setup.hs
+++ b/test/testdata/hieBiosMainIs/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/testdata/hieBiosMainIs/hieBiosMainIs.cabal
+++ b/test/testdata/hieBiosMainIs/hieBiosMainIs.cabal
@@ -1,0 +1,8 @@
+cabal-version:       >=1.10
+name:                hieBiosMainIs
+version:             0.1.0.0
+build-type:          Simple
+executable hieBiosMainIs
+  main-is:             Main.hs
+  build-depends:       base >=4.12 && <4.13
+  default-language:    Haskell2010


### PR DESCRIPTION
This fixes loading a file listed inside a main-is of an executable with the implicit cabal-helper cradle