### PR TITLE
Update hie-plugin-api for use with HaRe

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/GhcCompat.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcCompat.hs
@@ -158,7 +158,9 @@ namesFromHsIbWc :: HsTypes.LHsSigWcType GhcRn -> [Name]
 namesFromHsIbSig :: HsTypes.LHsSigType GhcRn -> [Name]
 namesFromHsWC :: HsTypes.LHsWcType GhcRn -> [Name]
 -- | Monomorphising type so uniplate is happier.
-#if __GLASGOW_HASKELL__ >= 806
+#if __GLASGOW_HASKELL__ >= 808
+namesFromHsIbSig = HsTypes.hsib_ext
+#elif __GLASGOW_HASKELL__ >= 806
 namesFromHsIbSig = hsib_vars . HsTypes.hsib_ext
 #else
 namesFromHsIbSig = HsTypes.hsib_vars

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -23,7 +23,6 @@ module Haskell.Ide.Engine.ModuleCache
   , cacheModules
   , cacheInfoNoClear
   , runActionWithContext
-  , runWithContext
   , ModuleCache(..)
   ) where
 
@@ -106,19 +105,6 @@ runActionWithContext _df Nothing _def action =
 runActionWithContext df (Just uri) def action = do
   mcradle <- getCradle uri
   loadCradle df mcradle def action
-
--- ---------------------------------------------------------------------
-
-runWithContext :: Monoid a => Uri -> IdeGhcM (IdeResult a) -> IdeGhcM (IdeResult a)
-runWithContext uri act = case uriToFilePath uri of
-  Just fp -> do
-    df <- GHC.getSessionDynFlags
-    res <- runActionWithContext df (Just fp) (IdeResultOk mempty) act
-    case res of
-      IdeResultOk a -> return a
-      IdeResultFail err -> error $ "Could not run in context: " ++ show err
-  Nothing -> error $ "uri not valid: " ++ show uri
-
 
 -- ---------------------------------------------------------------------
 

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginApi.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginApi.hs
@@ -38,7 +38,8 @@ module Haskell.Ide.Engine.PluginApi
   , HIE.IdeState(..)
   , HIE.IdeGhcM
   , HIE.runIdeGhcM
-  , runIdeGhcMBare
+  , HIE.runIdeGhcMBare
+  , HIE.runWithContext
   , HIE.IdeM
   , HIE.runIdeM
   , HIE.IdeDeferM
@@ -61,6 +62,8 @@ module Haskell.Ide.Engine.PluginApi
   , BiosLogLevel
   , BiosOptions
   , defaultOptions
+  , HIE.BIOSVerbosity(..)
+  , HIE.CradleOpts(..)
   ) where
 
 
@@ -68,7 +71,7 @@ module Haskell.Ide.Engine.PluginApi
 import qualified GhcProject.Types                    as GP
 import qualified Haskell.Ide.Engine.Ghc              as HIE
 import qualified Haskell.Ide.Engine.GhcModuleCache   as HIE (CachedInfo(..),HasGhcModuleCache(..))
-import qualified Haskell.Ide.Engine.ModuleCache      as HIE (ifCachedModule)
+import qualified Haskell.Ide.Engine.ModuleCache      as HIE (ifCachedModule, runWithContext)
 import qualified Haskell.Ide.Engine.PluginsIdeMonads as HIE
 import qualified Language.Haskell.LSP.Types          as LSP ( filePathToUri )
 import qualified HIE.Bios.Types as HIE
@@ -78,5 +81,5 @@ defaultOptions = HIE.defaultCradleOpts
 type BiosLogLevel = HIE.BIOSVerbosity
 
 type BiosOptions = HIE.CradleOpts
-runIdeGhcMBare :: a
-runIdeGhcMBare = error "Not implemented"
+-- runIdeGhcMBare :: a
+-- runIdeGhcMBare = error "Not implemented"

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginApi.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginApi.hs
@@ -38,8 +38,7 @@ module Haskell.Ide.Engine.PluginApi
   , HIE.IdeState(..)
   , HIE.IdeGhcM
   , HIE.runIdeGhcM
-  , HIE.runIdeGhcMBare
-  , HIE.runWithContext
+  , HIE.runActionWithContext
   , HIE.IdeM
   , HIE.runIdeM
   , HIE.IdeDeferM
@@ -55,8 +54,11 @@ module Haskell.Ide.Engine.PluginApi
   , HIE.Diagnostics
   , HIE.AdditionalErrs
   , LSP.filePathToUri
+  , LSP.uriToFilePath
+  , LSP.Uri
   , HIE.ifCachedModule
   , HIE.CachedInfo(..)
+  , HIE.IdeResult(..)
 
   -- * used for tests in HaRe
   , BiosLogLevel
@@ -64,16 +66,18 @@ module Haskell.Ide.Engine.PluginApi
   , defaultOptions
   , HIE.BIOSVerbosity(..)
   , HIE.CradleOpts(..)
+  , emptyIdePlugins
+  , emptyIdeState
   ) where
 
 
 
 import qualified GhcProject.Types                    as GP
 import qualified Haskell.Ide.Engine.Ghc              as HIE
-import qualified Haskell.Ide.Engine.GhcModuleCache   as HIE (CachedInfo(..),HasGhcModuleCache(..))
-import qualified Haskell.Ide.Engine.ModuleCache      as HIE (ifCachedModule, runWithContext)
+import qualified Haskell.Ide.Engine.GhcModuleCache   as HIE (CachedInfo(..),HasGhcModuleCache(..),emptyModuleCache)
+import qualified Haskell.Ide.Engine.ModuleCache      as HIE (ifCachedModule,runActionWithContext )
 import qualified Haskell.Ide.Engine.PluginsIdeMonads as HIE
-import qualified Language.Haskell.LSP.Types          as LSP ( filePathToUri )
+import qualified Language.Haskell.LSP.Types          as LSP ( filePathToUri, uriToFilePath, Uri )
 import qualified HIE.Bios.Types as HIE
 
 defaultOptions :: HIE.CradleOpts
@@ -81,5 +85,9 @@ defaultOptions = HIE.defaultCradleOpts
 type BiosLogLevel = HIE.BIOSVerbosity
 
 type BiosOptions = HIE.CradleOpts
--- runIdeGhcMBare :: a
--- runIdeGhcMBare = error "Not implemented"
+
+emptyIdePlugins :: HIE.IdePlugins
+emptyIdePlugins = HIE.IdePlugins mempty
+
+emptyIdeState :: HIE.IdeState
+emptyIdeState = HIE.IdeState HIE.emptyModuleCache mempty mempty Nothing

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -57,7 +57,7 @@ import           Language.Haskell.LSP.VFS
 import           Language.Haskell.LSP.Types.Capabilities
 import qualified Language.Haskell.LSP.Types            as J
 import           Prelude                               hiding (log)
-import           SrcLoc
+import           SrcLoc (SrcSpan(..), RealSrcSpan(..))
 import           Exception
 import           System.Directory
 import           System.FilePath

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -51,7 +51,6 @@ module Haskell.Ide.Engine.PluginsIdeMonads
   , IdeState(..)
   , IdeGhcM
   , runIdeGhcM
-  , runIdeGhcMBare
   , IdeM
   , runIdeM
   , IdeDeferM
@@ -124,7 +123,6 @@ import           Data.Typeable                  ( TypeRep
 import System.Directory
 import GhcMonad
 import qualified HIE.Bios.Ghc.Api as BIOS
-import qualified HIE.Bios.Types   as BIOS (CradleOpts(..))
 import           GHC.Generics
 import           GHC                            ( HscEnv )
 import Exception
@@ -359,19 +357,6 @@ runIdeGhcM :: IdePlugins -> Maybe (Core.LspFuncs Config) -> TVar IdeState -> Ide
 runIdeGhcM plugins mlf stateVar f = do
   env <- IdeEnv <$> pure mlf <*> getProcessID <*> pure plugins
   flip runReaderT stateVar $ flip runReaderT env $ BIOS.withGhcT f
-
-
--- | Run an IdeGhcM in an external context (e.g. HaRe), with no plugins or LSP functions
--- runIdeGhcMBare :: BiosOptions -> IdeGhcM a -> IO a
-runIdeGhcMBare :: BIOS.CradleOpts -> IdeGhcM a -> IO a
-runIdeGhcMBare _biosOptions f = do
-  let
-    plugins  = IdePlugins Map.empty
-    mlf      = Nothing
-    initialState = IdeState emptyModuleCache Map.empty Map.empty Nothing
-  stateVar <- newTVarIO initialState
-  -- runIdeGhcM biosOptions plugins mlf stateVar f
-  runIdeGhcM plugins mlf stateVar f
 
 -- | A computation that is deferred until the module is cached.
 -- Note that the module may not typecheck, in which case 'UriCacheFailed' is passed

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -51,7 +51,7 @@ module Haskell.Ide.Engine.PluginsIdeMonads
   , IdeState(..)
   , IdeGhcM
   , runIdeGhcM
- -- , runIdeGhcMBare
+  , runIdeGhcMBare
   , IdeM
   , runIdeM
   , IdeDeferM
@@ -124,6 +124,7 @@ import           Data.Typeable                  ( TypeRep
 import System.Directory
 import GhcMonad
 import qualified HIE.Bios.Ghc.Api as BIOS
+import qualified HIE.Bios.Types   as BIOS (CradleOpts(..))
 import           GHC.Generics
 import           GHC                            ( HscEnv )
 import Exception
@@ -359,17 +360,18 @@ runIdeGhcM plugins mlf stateVar f = do
   env <- IdeEnv <$> pure mlf <*> getProcessID <*> pure plugins
   flip runReaderT stateVar $ flip runReaderT env $ BIOS.withGhcT f
 
-{-
+
 -- | Run an IdeGhcM in an external context (e.g. HaRe), with no plugins or LSP functions
-runIdeGhcMBare :: BiosOptions -> IdeGhcM a -> IO a
-runIdeGhcMBare biosOptions f = do
+-- runIdeGhcMBare :: BiosOptions -> IdeGhcM a -> IO a
+runIdeGhcMBare :: BIOS.CradleOpts -> IdeGhcM a -> IO a
+runIdeGhcMBare _biosOptions f = do
   let
     plugins  = IdePlugins Map.empty
     mlf      = Nothing
     initialState = IdeState emptyModuleCache Map.empty Map.empty Nothing
   stateVar <- newTVarIO initialState
-  runIdeGhcM biosOptions plugins mlf stateVar f
-  -}
+  -- runIdeGhcM biosOptions plugins mlf stateVar f
+  runIdeGhcM plugins mlf stateVar f
 
 -- | A computation that is deferred until the module is cached.
 -- Note that the module may not typecheck, in which case 'UriCacheFailed' is passed

--- a/src/Haskell/Ide/Engine/Scheduler.hs
+++ b/src/Haskell/Ide/Engine/Scheduler.hs
@@ -328,14 +328,14 @@ ghcDispatcher env@DispatcherEnv { docVersionTVar } errorHandler callbackHandler 
 
     let
       runner :: a -> IdeGhcM a -> IdeGhcM (IdeResult  a)
-      runner d act = case context of
-        Nothing  -> runActionWithContext iniDynFlags Nothing d act
+      runner d' act = case context of
+        Nothing  -> runActionWithContext iniDynFlags Nothing d' act
         Just uri -> case uriToFilePath uri of
-          Just fp -> runActionWithContext iniDynFlags (Just fp) d act
+          Just fp -> runActionWithContext iniDynFlags (Just fp) d' act
           Nothing -> do
             debugm
               "ghcDispatcher:Got malformed uri, running action with default context"
-            runActionWithContext iniDynFlags Nothing d act
+            runActionWithContext iniDynFlags Nothing d' act
 
     let
       runWithCallback = do

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -48,6 +48,18 @@ dispatchRequestPGoto =
 
 -- ---------------------------------------------------------------------
 
+runWithContext :: Monoid a => Uri -> IdeGhcM (IdeResult a) -> IdeGhcM (IdeResult a)
+runWithContext uri act = case uriToFilePath uri of
+  Just fp -> do
+    df <- getSessionDynFlags
+    res <- runActionWithContext df (Just fp) (IdeResultOk mempty) act
+    case res of
+      IdeResultOk a -> return a
+      IdeResultFail err -> error $ "Could not run in context: " ++ show err
+  Nothing -> error $ "uri not valid: " ++ show uri
+
+-- ---------------------------------------------------------------------
+
 hareSpec :: Spec
 hareSpec = do
   describe "hare plugin commands(old plugin api)" $ do

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -11,6 +11,7 @@ import           Data.Aeson
 import qualified Data.Map                      as M
 import qualified Data.HashMap.Strict           as H
 import           Haskell.Ide.Engine.Ghc
+import           Haskell.Ide.Engine.PluginApi
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Plugin.HaRe
@@ -21,7 +22,6 @@ import           Language.Haskell.LSP.Types     ( Location(..)
 import           System.Directory
 import           System.FilePath
 import           TestUtils
-import GhcMonad
 import           Test.Hspec
 
 -- ---------------------------------------------------------------------
@@ -47,16 +47,6 @@ dispatchRequestPGoto =
     . runIGM testPlugins
 
 -- ---------------------------------------------------------------------
-
-runWithContext :: Monoid a => Uri -> IdeGhcM (IdeResult a) -> IdeGhcM (IdeResult a)
-runWithContext uri act = case uriToFilePath uri of
-  Just fp -> do
-    df <- getSessionDynFlags
-    res <- runActionWithContext df (Just fp) (IdeResultOk mempty) act
-    case res of
-      IdeResultOk a -> return a
-      IdeResultFail err -> error $ "Could not run in context: " ++ show err
-  Nothing -> error $ "uri not valid: " ++ show uri
 
 hareSpec :: Spec
 hareSpec = do


### PR DESCRIPTION
This removes `runIdeGhcMBare` and `runWithContext`.

At least one of the `HaRe` tests runs, able to load a file using `hie-bios`.

So it is a matter of fixing the rest now.

And coming up with a way of requesting the module graph of a project, to know which modules anywhere in a project are importing the module being refactored.