### PR TITLE
specific ghc-exactprint for all-hies HaRe

### DIFF
--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -33,6 +33,7 @@ extra-deps:
 # To make build work in windows 7
 - unix-time-0.4.7
 # - hie-bios-0.2.1@sha256:5f98a3516ce65e0a3ffd88bf6fb416b04cc084371d0fbf0e1762780de1d652ce,3219
+- ghc-exactprint-0.6.2 # for HaRe
 
 - extra-1.6.18@sha256:5f1fff126f0ae47b701fff5aa8462dc63cb44465d5a724b0afd20a3d731903af
 - unix-compat-0.5.2@sha256:16763f1fae4a25abf61ac6195eb530ce838474bd04d86c7d353340aee8716bbb


### PR DESCRIPTION
Maybe this should be fixed in `HaRe` or `all-hies` instead?