### PR TITLE
Create empty hie.yaml to trigger the parse error

### DIFF
--- a/test/functional/HieBiosSpec.hs
+++ b/test/functional/HieBiosSpec.hs
@@ -6,19 +6,29 @@ import qualified Data.Text as T
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Messages
+import System.FilePath ((</>))
 import Test.Hspec
 import TestUtils
 
 spec :: Spec
-spec = describe "hie-bios" $ do
-  it "loads modules inside main-is" $ runSession hieCommand fullCaps "test/testdata/hieBiosMainIs" $ do
-    _ <- openDoc "Main.hs" "haskell"
-    _ <- count 2 waitForDiagnostics
-    return ()
-  it "reports errors in hie.yaml" $ runSession hieCommand fullCaps "test/testdata/hieBiosError" $ do
-    _ <- openDoc "Foo.hs" "haskell"
-    _ <- skipManyTill loggingNotification (satisfy isMessage)
-    return ()
-  where isMessage (NotShowMessage (NotificationMessage _ _ (ShowMessageParams MtError s))) =
+-- Create an empty hie.yaml to trigger the parse error
+spec = beforeAll_ (writeFile (hieBiosErrorPath </> "hie.yaml") "") $ do
+
+  describe "hie-bios" $ do
+
+    it "loads modules inside main-is" $ runSession hieCommand fullCaps "test/testdata/hieBiosMainIs" $ do
+      _ <- openDoc "Main.hs" "haskell"
+      _ <- count 2 waitForDiagnostics
+      return ()
+  
+    it "reports errors in hie.yaml" $ runSession hieCommand fullCaps hieBiosErrorPath $ do
+      _ <- openDoc "Foo.hs" "haskell"
+      _ <- skipManyTill loggingNotification (satisfy isMessage)
+      return ()
+  
+  where hieBiosErrorPath = "test/testdata/hieBiosError"
+  
+        isMessage (NotShowMessage (NotificationMessage _ _ (ShowMessageParams MtError s))) =
           "Couldn't parse hie.yaml" `T.isInfixOf` s
         isMessage _ = False
+        


### PR DESCRIPTION
* Fix the failing functional test `reports errors in hie.yaml`
* I create the file here instead in https://github.com/mpickering/haskell-ide-engine/blob/hie-bios/test/utils/TestUtils.hs#L98 cause it is somewaht exceptional (a bad file to trigger an error) but let me know if you think it should be there 