### PR TITLE
Restore typed holes substitution list from master

### DIFF
--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -336,7 +336,7 @@ spec = describe "code actions" $ do
               GHC86 -> do
                 liftIO $ map (^. L.title) cas `shouldMatchList`
                   [ "Substitute hole (Int) with x ([Int])"
-                  , "Substitute hole (Int) with foo ([Int] -> Int)"
+                  , "Substitute hole (Int) with foo ([Int] -> Int Valid hole fits include)"
                   , "Substitute hole (Int) with maxBound (forall a. Bounded a => a with maxBound @Int)"
                   , "Substitute hole (Int) with minBound (forall a. Bounded a => a with minBound @Int)"
                   ]


### PR DESCRIPTION
* This would fix an actual failing test in the hie-bios branch
* This is the actual hie master version of the substitution list: https://github.com/haskell/haskell-ide-engine/blob/master/test/functional/FunctionalCodeActionsSpec.hs#L339
* However it seems the correct substitution should be without the ` Valid hole fits include`
  * It was removed with 805961d by @wz1000 and included in [this](https://github.com/mpickering/haskell-ide-engine/pull/4/) pr
  * So maybe other change *corrected* the substitution and it doesnt work now, but i am not able to find which one 