### PR TITLE
Fix wrapper tests when cabal is installed

### DIFF
--- a/test/testdata/wrapper/8.2.1/cabal.project
+++ b/test/testdata/wrapper/8.2.1/cabal.project
@@ -1,1 +1,0 @@
-packages: .

--- a/test/testdata/wrapper/lts-11.14/cabal.project
+++ b/test/testdata/wrapper/lts-11.14/cabal.project
@@ -1,1 +1,0 @@
-packages: .


### PR DESCRIPTION
The new cabal-helper now prefers cabal-v2 cradles over stack cradles whenever there is a cabal.project file present in a directory. These presumably passed on CI since cabal isn't installed, just stack? Either way removing the cabal.project files cause the stack project to be preferred, which is what the tests seemed to originally want.