### PR TITLE
Add explicit hie.yaml to force the project type

### DIFF
--- a/test/testdata/wrapper/8.2.1/hie.yaml
+++ b/test/testdata/wrapper/8.2.1/hie.yaml
@@ -1,0 +1,3 @@
+# TODO: generate this in test suite
+cradle:
+  stack:

--- a/test/testdata/wrapper/lts-11.14/hie.yaml
+++ b/test/testdata/wrapper/lts-11.14/hie.yaml
@@ -1,0 +1,3 @@
+# TODO: generate this in test suite
+cradle:
+  stack:


### PR DESCRIPTION
cc @bubba 
~We need to this, since c-h would trace the ancestors of these directories and still find cabal.project in `haskell-ide-engine`, still selecting a cabal cradle.~
EDIT: I think this happens because we generate an automatic `hie.yaml` in the parent `test/testdata` directory.
With an explicit hie.yaml, we force the project type. Should be probably generated.