### PR TITLE
Update hie-bios version to at least 0.3.2

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -96,7 +96,7 @@ library
                      , vector
                      , versions
                      , yaml >= 0.8.31
-                     , hie-bios == 0.3.*
+                     , hie-bios >= 0.3.2 && < 0.4.0
                      , bytestring-trie
                      , unliftio
                      , hlint >= 2.2.2

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -49,7 +49,7 @@ library
                      , fingertree
                      , free
                      , ghc
-                     , hie-bios == 0.3.*
+                     , hie-bios >= 0.3.2 && < 0.4.0
                      , ghc-project-types >= 5.9.0.0
                      , cabal-helper
                      , haskell-lsp == 0.19.*

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -24,7 +24,7 @@ extra-deps:
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -24,7 +24,7 @@ extra-deps:
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -23,7 +23,7 @@ extra-deps:
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -27,7 +27,7 @@ extra-deps:
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -23,7 +23,7 @@ extra-deps:
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -21,7 +21,7 @@ extra-deps:
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
@@ -33,7 +33,6 @@ extra-deps:
 - temporary-1.2.1.1
 # To make build work in windows 7
 - unix-time-0.4.7
-# - hie-bios-0.2.1@sha256:5f98a3516ce65e0a3ffd88bf6fb416b04cc084371d0fbf0e1762780de1d652ce,3219
 
 - extra-1.6.18@sha256:5f1fff126f0ae47b701fff5aa8462dc63cb44465d5a724b0afd20a3d731903af
 - unix-compat-0.5.2@sha256:16763f1fae4a25abf61ac6195eb530ce838474bd04d86c7d353340aee8716bbb

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - haddock-api-2.22.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hsimport-0.11.0
 - hoogle-5.0.17.11
@@ -29,7 +29,6 @@ extra-deps:
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - clock-0.7.2
-#  - hie-bios-0.2.1@sha256:5f98a3516ce65e0a3ffd88bf6fb416b04cc084371d0fbf0e1762780de1d652ce,3219
 
 flags:
   haskell-ide-engine:

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - haddock-api-2.22.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
-- hie-bios-0.3.0
+- hie-bios-0.3.2
 - hlint-2.2.4
 - hsimport-0.11.0
 - lsp-test-0.9.0.0
@@ -29,7 +29,6 @@ extra-deps:
 - temporary-1.2.1.1
 - clock-0.7.2
 - ghc-exactprint-0.6.2 # for HaRe
-# - hie-bios-0.2.1@sha256:5f98a3516ce65e0a3ffd88bf6fb416b04cc084371d0fbf0e1762780de1d652ce,3219
 - extra-1.6.18
 - unix-compat-0.5.2
 - yaml-0.11.1.2


### PR DESCRIPTION
hie-bios was broken on windows, bug fixes have already been published, see https://github.com/mpickering/hie-bios/issues/110 and https://github.com/mpickering/hie-bios/issues/109 for details.

EDIT: CircleCI results https://circleci.com/workflow-run/4bb9e6a6-e602-411a-9844-8bd8c7575576
Dont merge before everything is green, please!